### PR TITLE
Validate database schema consistency

### DIFF
--- a/DATABASE_SCHEMA_REVIEW_REPORT.md
+++ b/DATABASE_SCHEMA_REVIEW_REPORT.md
@@ -1,0 +1,133 @@
+# Database Schema Review Report
+
+## Overview
+This report documents the comprehensive review of the database schema against the provided database structure. Several critical issues were identified and resolved to ensure consistency between the actual database schema, the Drizzle ORM schema definitions, and the SQL initialization files.
+
+## Issues Found and Resolved
+
+### 1. **Data Type Mismatches**
+
+**Issue**: The `accounts.expires_at` field had inconsistent data types across different files.
+- **Database Schema (provided)**: `bigint`
+- **Drizzle Schema**: `integer` ❌
+- **SQL init file**: `BIGINT` ✅
+
+**Fix Applied**: Updated `db/schema.ts` to use `bigint("expires_at", { mode: "number" })` instead of `integer("expires_at")` and added the missing `bigint` import.
+
+### 2. **Field Name Inconsistencies**
+
+**Issue**: The `accounts` table in `init.sql` had a `user_state` field that doesn't exist in the provided schema.
+- **Expected**: `session_state`
+- **Found**: `user_state` ❌
+
+**Fix Applied**: Corrected `db/init.sql` to use `session_state` instead of `user_state`.
+
+### 3. **Duplicate and Incorrect Table Definitions**
+
+**Issue**: The `init.sql` file contained:
+- Duplicate `CREATE TABLE users` statement (should be `sessions`)
+- Incorrect field name `userToken` (should be `sessionToken`)
+
+**Fix Applied**: Corrected the second table definition to properly create the `sessions` table with the correct field names.
+
+### 4. **Missing Tables in SQL Init File**
+
+**Issue**: The following tables were defined in the Drizzle schema but missing from `init.sql`:
+- `habits`
+- `habitCompletions`
+
+**Fix Applied**: Added proper `CREATE TABLE` statements for both tables to `db/init.sql`.
+
+### 5. **Missing Fields in Tables**
+
+**Issue**: The `notes` table was missing the `updatedAt` field in the SQL init file.
+
+**Fix Applied**: Added `"updatedAt" TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()` to the notes table definition.
+
+### 6. **Array Type Inconsistencies**
+
+**Issue**: Journal tables had inconsistent array type definitions:
+- **SQL files**: Used `TEXT[]` correctly
+- **Drizzle schema**: Used `jsonb()` for arrays ❌
+
+**Fix Applied**: Updated the following fields in `db/schema.ts` to use `text().array()`:
+- `journalActivities.activities`
+- `journalMoods.tags`
+
+### 7. **Additional Tables Analysis**
+
+**Review Finding**: The Drizzle schema contains several additional tables not present in the provided database schema:
+- `pushSubscriptions` - Used for web push notifications ✅
+- `calendarEvents` - Used for calendar functionality ✅
+- `analyticsPerformanceMetrics` - Used for performance tracking ✅
+- `analyticsUsersDurations` - Used for user session tracking ✅
+- `analyticsPageVisits` - Used for page visit tracking ✅
+- `analyticsWidgetUsage` - Used for widget usage tracking ✅
+- `feedback` - Used for user feedback system ✅
+- `backlog` - Used for feedback management ✅
+- `meetings` - Used for meeting notes functionality ✅
+
+**Status**: These tables are actively used in the codebase and should be retained. They represent additional features beyond the core schema.
+
+## Database Configuration Improvements
+
+### 1. **Added Drizzle Configuration**
+Created `drizzle.config.ts` with proper configuration for:
+- Schema location
+- Migration output directory
+- Database credentials
+- Verbose logging
+- Strict mode validation
+
+### 2. **Enhanced Package.json Scripts**
+Added database management scripts:
+- `db:generate` - Generate migrations
+- `db:migrate` - Run migrations
+- `db:push` - Push schema to database
+- `db:studio` - Open Drizzle Studio
+- `db:init` - Initialize database with init.sql
+
+### 3. **Added Missing Dependencies**
+Added `tsx` to devDependencies for running TypeScript files directly.
+
+## Validation Status
+
+### ✅ Resolved Issues
+- [x] Data type consistency (bigint vs integer)
+- [x] Field name consistency (session_state vs user_state)
+- [x] Duplicate table definitions
+- [x] Missing tables in SQL init file
+- [x] Missing fields in existing tables
+- [x] Array type definitions
+- [x] Import statements
+- [x] Configuration files
+- [x] Package.json scripts
+
+### ⚠️ Recommendations
+
+1. **Run Migration Generation**: Execute `npm run db:generate` to create proper migration files based on the current schema.
+
+2. **Database Initialization**: Use `npm run db:init` to initialize a fresh database with the corrected schema.
+
+3. **Schema Validation**: Use `npm run db:studio` to visually inspect the database schema and verify all changes.
+
+4. **Environment Variables**: Ensure `NEON_DATABASE_URL` is properly set in your `.env.local` file.
+
+5. **Testing**: Test all API endpoints that interact with the corrected tables, especially:
+   - `/api/tasks` (tasks table)
+   - `/api/userSettings` (user_settings table)
+   - `/api/habits/*` (habits and habitCompletions tables)
+   - `/api/journal/*` (journal_* tables)
+   - `/api/analytics/*` (analytics tables)
+
+## Summary
+
+The database schema review identified and resolved **7 critical issues** affecting data type consistency, table structure, and field definitions. The codebase now has:
+
+- ✅ Consistent data types across all schema definitions
+- ✅ Proper table structure matching the provided schema
+- ✅ Complete SQL initialization files
+- ✅ Proper Drizzle ORM configuration
+- ✅ Enhanced development workflow with database scripts
+
+All changes maintain backward compatibility while ensuring the database schema matches the provided specification exactly.

--- a/db/init.sql
+++ b/db/init.sql
@@ -19,15 +19,15 @@ CREATE TABLE IF NOT EXISTS accounts (
     expires_at BIGINT,
     id_token TEXT,
     scope TEXT,
-    user_state TEXT,
+    session_state TEXT,
     token_type VARCHAR(255),
     CONSTRAINT "provider_account_id" UNIQUE (provider, "providerAccountId")
 );
 
-CREATE TABLE IF NOT EXISTS users (
+CREATE TABLE IF NOT EXISTS sessions (
     id SERIAL PRIMARY KEY,
     "userId" INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    "userToken" VARCHAR(255) NOT NULL UNIQUE,
+    "sessionToken" VARCHAR(255) NOT NULL UNIQUE,
     expires TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
@@ -82,7 +82,8 @@ CREATE TABLE IF NOT EXISTS notes (
     is_adhoc BOOLEAN DEFAULT FALSE,
     actions JSONB,
     agenda TEXT,
-    ai_summary TEXT
+    ai_summary TEXT,
+    "updatedAt" TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS journal_activities (
@@ -141,4 +142,25 @@ CREATE TABLE IF NOT EXISTS journal_entries (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     UNIQUE (user_email, date)
+);
+
+CREATE TABLE IF NOT EXISTS habits (
+    id SERIAL PRIMARY KEY,
+    "userId" VARCHAR(255) NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    frequency TEXT NOT NULL,
+    "customDays" JSONB,
+    "createdAt" TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
+    "updatedAt" TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS "habitCompletions" (
+    id SERIAL PRIMARY KEY,
+    "habitId" INTEGER NOT NULL REFERENCES habits(id) ON DELETE CASCADE,
+    "userId" VARCHAR(255) NOT NULL,
+    date TEXT NOT NULL,
+    completed BOOLEAN DEFAULT FALSE,
+    notes TEXT,
+    timestamp TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
 );

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -9,6 +9,7 @@ import {
   varchar,
   jsonb,
   uniqueIndex,
+  bigint,
 } from 'drizzle-orm/pg-core';
 import { InferSelectModel, InferInsertModel, relations } from 'drizzle-orm';
 
@@ -38,7 +39,7 @@ export const accounts = pgTable(
     providerAccountId: varchar("providerAccountId", { length: 255 }).notNull(),
     refresh_token: text("refresh_token"),
     access_token: text("access_token"),
-    expires_at: integer("expires_at"),
+    expires_at: bigint("expires_at", { mode: "number" }),
     token_type: varchar("token_type", { length: 255 }),
     scope: text("scope"),
     id_token: text("id_token"),
@@ -266,7 +267,7 @@ export const journalActivities = pgTable("journal_activities", {
   id: serial("id").notNull().primaryKey(),
   user_email: varchar("user_email", { length: 255 }).notNull(),
   date: text("date").notNull(),
-  activities: jsonb("activities"),
+  activities: text("activities").array(),
   createdAt: timestamp("created_at", { mode: "date" }).defaultNow(),
   updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow(),
 });
@@ -288,7 +289,7 @@ export const journalMoods = pgTable("journal_moods", {
   date: text("date").notNull(),
   emoji: text("emoji"),
   label: text("label"),
-  tags: jsonb("tags"),
+  tags: text("tags").array(),
   createdAt: timestamp("created_at", { mode: "date" }).defaultNow(),
   updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow(),
 });

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -6,9 +6,9 @@ dotenv.config({ path: '.env.local' });
 export default {
   schema: './db/schema.ts',
   out: './db/migrations',
-  driver: 'pg',
+  dialect: 'postgresql',
   dbCredentials: {
-    connectionString: process.env.NEON_DATABASE_URL!,
+    url: process.env.NEON_DATABASE_URL!,
   },
   verbose: true,
   strict: true,

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from 'drizzle-kit';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: '.env.local' });
+
+export default {
+  schema: './db/schema.ts',
+  out: './db/migrations',
+  driver: 'pg',
+  dbCredentials: {
+    connectionString: process.env.NEON_DATABASE_URL!,
+  },
+  verbose: true,
+  strict: true,
+} satisfies Config;

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "db:generate": "drizzle-kit generate:pg",
+    "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:push": "drizzle-kit push:pg",
+    "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "db:init": "tsx scripts/init-db.ts"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,12 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "db:generate": "drizzle-kit generate:pg",
+    "db:migrate": "drizzle-kit migrate",
+    "db:push": "drizzle-kit push:pg",
+    "db:studio": "drizzle-kit studio",
+    "db:init": "tsx scripts/init-db.ts"
   },
   "dependencies": {
     "@auth/pg-adapter": "^1.10.0",
@@ -80,6 +85,7 @@
     "eslint-config-next": "^14.2.0",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.1",
+    "tsx": "^4.0.0",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
Align database schema definitions and Drizzle Kit configuration to resolve inconsistencies and deployment issues.

The initial review identified several discrepancies between the provided database schema, the Drizzle ORM schema, and the SQL initialization script, including data type mismatches, missing tables/fields, and incorrect column names. Additionally, the Drizzle Kit configuration was updated to be compatible with the installed version (v0.31.4), which resolves a `Type error: Type '"pg"' is not assignable to type '"d1-http"'` compilation error during deployment.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-40ffc4a5-02cd-4024-9d79-7bf5b1399f12) · [Cursor](https://cursor.com/background-agent?bcId=bc-40ffc4a5-02cd-4024-9d79-7bf5b1399f12)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)