### PR TITLE
Fix calendarsource type error

### DIFF
--- a/pages/api/auth/callback/google-additional.ts
+++ b/pages/api/auth/callback/google-additional.ts
@@ -5,6 +5,7 @@ import { getUserById } from "@/lib/user";
 import { db } from "@/lib/drizzle";
 import { accounts } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
+import type { CalendarSource } from "@/types/app";
 
 export default async function handler(
   req: NextApiRequest,


### PR DESCRIPTION
Add missing import for `CalendarSource` type to fix deployment error.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-3c8bf953-174c-4539-8d51-85ad29888a01) · [Cursor](https://cursor.com/background-agent?bcId=bc-3c8bf953-174c-4539-8d51-85ad29888a01)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)