### PR TITLE
Move chat widget and clean header

### DIFF
--- a/WEATHER_SETUP.md
+++ b/WEATHER_SETUP.md
@@ -1,0 +1,38 @@
+# Weather API Setup
+
+To enable the weather widget functionality, you need to set up an OpenWeatherMap API key.
+
+## Setup Instructions
+
+1. **Get an API Key**:
+   - Go to [OpenWeatherMap](https://openweathermap.org/api)
+   - Sign up for a free account
+   - Get your API key from the dashboard
+
+2. **Add Environment Variable**:
+   - Create or update your `.env.local` file
+   - Add the following line:
+   ```
+   NEXT_PUBLIC_OPENWEATHER_API_KEY=your_api_key_here
+   ```
+
+3. **Restart Development Server**:
+   - Stop your development server
+   - Run `npm run dev` again
+
+## Features
+
+- **Automatic Location Detection**: Uses browser geolocation to get user's location
+- **Real-time Weather**: Shows current temperature and weather conditions
+- **Responsive Design**: Works on both desktop and mobile
+- **Error Handling**: Gracefully handles location and API errors
+
+## Weather Widget Location
+
+The weather widget is now located in the top header bar, next to the chat toggle button and lock/unlock button.
+
+## Notes
+
+- The weather widget will request location permission from the user
+- If location is denied or unavailable, it will show "Weather unavailable"
+- The widget is designed to be lightweight and non-intrusive

--- a/components/assistant/ChatWidget.tsx
+++ b/components/assistant/ChatWidget.tsx
@@ -99,8 +99,9 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ onClose }) => {
     <div role="dialog" aria-label="FloCat chat" className="
       w-full h-full
       flex flex-col
+      p-4
     ">
-        <div className="flex-1 overflow-y-auto space-y-2 mb-2 text-[var(--fg)] dark:text-gray-100" ref={messagesEndRef}>
+        <div className="flex-1 overflow-y-auto space-y-2 mb-4 text-[var(--fg)] dark:text-gray-100 min-h-0" ref={messagesEndRef}>
           {/* Welcome message and quick actions */}
           {showQuickActions && (
             <div className="space-y-3">
@@ -163,7 +164,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ onClose }) => {
             </div>
           )}
         </div>
-        <div className="flex border-t border-[var(--neutral-300)] dark:border-gray-600 p-4">
+        <div className="flex border-t border-[var(--neutral-300)] dark:border-gray-600 pt-4 pb-2">
           <input
             className="
               flex-1 border border-[var(--neutral-300)] dark:border-gray-600

--- a/components/assistant/ChatWidget.tsx
+++ b/components/assistant/ChatWidget.tsx
@@ -97,8 +97,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ onClose }) => {
 
       return (
     <div role="dialog" aria-label="FloCat chat" className="
-      w-80 h-96
-      glass p-4 rounded-xl shadow-elevate-lg
+      w-full h-full
       flex flex-col
     ">
         <div className="flex-1 overflow-y-auto space-y-2 mb-2 text-[var(--fg)] dark:text-gray-100" ref={messagesEndRef}>
@@ -164,11 +163,11 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ onClose }) => {
             </div>
           )}
         </div>
-        <div className="flex border-t border-[var(--neutral-300)] dark:border-gray-600 pt-2">
+        <div className="flex border-t border-[var(--neutral-300)] dark:border-gray-600 p-4">
           <input
             className="
               flex-1 border border-[var(--neutral-300)] dark:border-gray-600
-              rounded-l px-2 py-1 focus:outline-none
+              rounded-l px-3 py-2 focus:outline-none
               focus:ring-2 focus:ring-[var(--primary)]
               bg-white dark:bg-gray-700 text-[var(--fg)] dark:text-gray-100
               placeholder-gray-400 dark:placeholder-gray-400
@@ -182,7 +181,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ onClose }) => {
             onClick={handleSend} // Use handleSend
             disabled={loading || !input.trim()} // Disable if loading or input is empty
             className="
-              ml-2 px-3 rounded-r text-white
+              px-4 py-2 rounded-r text-white
               bg-[var(--accent)] hover:opacity-90
               disabled:opacity-50
             "
@@ -190,13 +189,6 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ onClose }) => {
             Send
           </button>
         </div>
-        <button
-          onClick={onClose}
-          aria-label="Close chat"
-          className="mt-2 text-sm text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100"
-        >
-          Close
-        </button>
       </div>
   );
 };

--- a/components/ui/ChatSideModal.tsx
+++ b/components/ui/ChatSideModal.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import React, { useEffect } from 'react';
+import { X, MessageCircle } from 'lucide-react';
+import ChatWidget from '../assistant/ChatWidget';
+import { useChat } from '../assistant/ChatContext';
+
+interface ChatSideModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const ChatSideModal: React.FC<ChatSideModalProps> = ({ isOpen, onClose }) => {
+  const { setIsChatOpen } = useChat();
+
+  // Handle escape key to close modal
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && isOpen) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      // Prevent body scroll when modal is open
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen, onClose]);
+
+  // Handle backdrop click
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={`fixed inset-0 bg-black/50 backdrop-blur-sm z-40 transition-opacity duration-300 ${
+          isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+        }`}
+        onClick={handleBackdropClick}
+      />
+
+      {/* Side Modal */}
+      <div
+        className={`fixed top-0 right-0 h-full w-full max-w-md bg-white dark:bg-neutral-900 shadow-2xl z-50 transform transition-transform duration-300 ease-in-out ${
+          isOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800">
+          <div className="flex items-center gap-2">
+            <MessageCircle className="w-5 h-5 text-primary-500" />
+            <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+              FloCat Chat
+            </h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-lg hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+            aria-label="Close chat"
+          >
+            <X className="w-5 h-5 text-neutral-600 dark:text-neutral-400" />
+          </button>
+        </div>
+
+        {/* Chat Content */}
+        <div className="h-full flex flex-col">
+          <div className="flex-1 overflow-hidden">
+            <ChatWidget onClose={onClose} />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ChatSideModal;

--- a/components/ui/ChatSideModal.tsx
+++ b/components/ui/ChatSideModal.tsx
@@ -39,7 +39,7 @@ const ChatSideModal: React.FC<ChatSideModalProps> = ({ isOpen, onClose }) => {
     <>
       {/* Side Modal */}
       <div
-        className={`fixed top-0 right-0 h-full w-full md:max-w-md bg-white dark:bg-neutral-900 shadow-2xl z-50 transform transition-transform duration-300 ease-in-out ${
+        className={`fixed top-0 right-0 h-full w-full max-w-sm md:max-w-md lg:max-w-lg bg-white dark:bg-neutral-900 shadow-2xl z-50 transform transition-transform duration-300 ease-in-out ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >
@@ -61,10 +61,8 @@ const ChatSideModal: React.FC<ChatSideModalProps> = ({ isOpen, onClose }) => {
         </div>
 
         {/* Chat Content */}
-        <div className="h-full flex flex-col">
-          <div className="flex-1 overflow-hidden">
-            <ChatWidget onClose={onClose} />
-          </div>
+        <div className="flex-1 overflow-hidden">
+          <ChatWidget onClose={onClose} />
         </div>
       </div>
     </>

--- a/components/ui/ChatSideModal.tsx
+++ b/components/ui/ChatSideModal.tsx
@@ -33,26 +33,13 @@ const ChatSideModal: React.FC<ChatSideModalProps> = ({ isOpen, onClose }) => {
     };
   }, [isOpen, onClose]);
 
-  // Handle backdrop click
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
-  };
+
 
   return (
     <>
-      {/* Backdrop */}
-      <div
-        className={`fixed inset-0 bg-black/50 backdrop-blur-sm z-40 transition-opacity duration-300 ${
-          isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
-        }`}
-        onClick={handleBackdropClick}
-      />
-
       {/* Side Modal */}
       <div
-        className={`fixed top-0 right-0 h-full w-full max-w-md bg-white dark:bg-neutral-900 shadow-2xl z-50 transform transition-transform duration-300 ease-in-out ${
+        className={`fixed top-0 right-0 h-full w-full md:max-w-md bg-white dark:bg-neutral-900 shadow-2xl z-50 transform transition-transform duration-300 ease-in-out ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >

--- a/components/ui/ChatToggleButton.tsx
+++ b/components/ui/ChatToggleButton.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import React from 'react';
+import { MessageCircle } from 'lucide-react';
+
+interface ChatToggleButtonProps {
+  onClick: () => void;
+  hasUnreadMessages?: boolean;
+}
+
+const ChatToggleButton: React.FC<ChatToggleButtonProps> = ({ 
+  onClick, 
+  hasUnreadMessages = false 
+}) => {
+  return (
+    <button
+      onClick={onClick}
+      className="relative p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors group"
+      aria-label="Open chat"
+    >
+      <MessageCircle className="w-5 h-5 text-neutral-600 dark:text-neutral-400 group-hover:text-primary-500 transition-colors" />
+      
+      {/* Unread indicator */}
+      {hasUnreadMessages && (
+        <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full animate-pulse">
+          <div className="w-full h-full bg-red-500 rounded-full animate-ping opacity-75"></div>
+        </div>
+      )}
+      
+      {/* Tooltip */}
+      <span className="absolute bottom-full mb-2 left-1/2 transform -translate-x-1/2 bg-black text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-10">
+        Chat with FloCat
+      </span>
+    </button>
+  );
+};
+
+export default ChatToggleButton;

--- a/components/ui/Layout.tsx
+++ b/components/ui/Layout.tsx
@@ -28,7 +28,6 @@ const Layout = ({ children }: { children: ReactNode }) => {
   const router = useRouter();
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [desktopSidebarCollapsed, setDesktopSidebarCollapsed] = useState(false);
-  const [topInput, setTopInput] = useState('');
 
   // -- AUTH --
   const { user } = useUser();
@@ -191,7 +190,9 @@ const Layout = ({ children }: { children: ReactNode }) => {
       </aside>
 
       {/* main */}
-      <div className="flex-1 flex flex-col transition-all duration-300 ease-in-out overflow-hidden">
+      <div className={`flex-1 flex flex-col transition-all duration-300 ease-in-out overflow-hidden ${
+        isChatOpen ? 'md:transform md:-translate-x-4' : ''
+      }`}>
         {/* header */}
         <header className="flex items-center justify-between p-4 bg-[var(--surface)] shadow-elevate-sm border-b border-neutral-200 dark:border-neutral-700">
           <div className="flex items-center">
@@ -213,39 +214,11 @@ const Layout = ({ children }: { children: ReactNode }) => {
             />
           </div>
 
-          {/* FloCat Chat Bubble */}
-          <div className="flex-1 flex justify-center relative">
-            <div className="w-full max-w-md relative">
-              <input
-                type="text"
-                placeholder="FloCat is here to help you... 🐱"
-                className="w-full p-2.5 pl-4 pr-10 rounded-full border border-neutral-300 dark:border-neutral-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-all shadow-sm hover:shadow bg-white dark:bg-neutral-800"
-                value={topInput}
-                onChange={(e) => setTopInput(e.target.value)}
-                onFocus={() => setIsChatOpen(true)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && isChatOpen && topInput.trim()) {
-                    handleTopInputSend();
-                  }
-                }}
-              />
-              <div className="absolute right-3 top-1/2 transform -translate-y-1/2 text-primary-500">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M22 2 11 13"/><path d="m22 2-7 20-4-9-9-4 20-7z"/></svg>
-              </div>
-            </div>
-            {isChatOpen && (
-              <div className="absolute top-full mt-2 left-1/2 transform -translate-x-1/2 z-50 animate-slide-up">
-                <ChatWidget
-                  onClose={() => setIsChatOpen(false)}
-                  key="chatwidget"
-                />
-              </div>
-            )}
-          </div>
-
-          <div className="flex items-center">
+          <div className="flex items-center gap-2">
+            <WeatherWidget />
+            <ChatToggleButton onClick={toggleChat} />
             <button
-              className="p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors ml-2 relative group"
+              className="p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors relative group"
               onClick={() => toggleLock()}
               aria-label={isLocked ? "Unlock layout" : "Lock layout"}
             >
@@ -267,6 +240,9 @@ const Layout = ({ children }: { children: ReactNode }) => {
           </div>
         </main>
       </div>
+
+      {/* Chat Side Modal */}
+      <ChatSideModal isOpen={isChatOpen} onClose={() => setIsChatOpen(false)} />
     </div>
   );
 };

--- a/components/ui/Layout.tsx
+++ b/components/ui/Layout.tsx
@@ -5,7 +5,9 @@ import { useRouter } from 'next/router';
 import { Menu, Home, ListTodo, Book, Calendar, Settings, LogOut, NotebookPen, UserIcon, NotebookPenIcon, NotepadText } from 'lucide-react'
 import Link from 'next/link'
 import Image from 'next/image'
-import ChatWidget from '../assistant/ChatWidget';
+import ChatSideModal from './ChatSideModal';
+import ChatToggleButton from './ChatToggleButton';
+import WeatherWidget from './WeatherWidget';
 import ThemeToggle from './ThemeToggle'
 import { useUser } from '@/lib/hooks/useUser';
 import { useChat } from '../assistant/ChatContext';
@@ -55,12 +57,6 @@ const Layout = ({ children }: { children: ReactNode }) => {
 
   // -- CHAT --
   const chatContext = useChat();
-  const history = chatContext?.history || [];
-  const send = chatContext?.send || (async () => {});
-  const status = chatContext?.status || 'idle';
-  const loading = chatContext?.loading || false;
-  const chatInput = chatContext?.input || '';
-  const setChatInput = chatContext?.setInput || (() => {});
   const isChatOpen = chatContext?.isChatOpen || false;
   const setIsChatOpen = chatContext?.setIsChatOpen || (() => {});
 
@@ -68,17 +64,8 @@ const Layout = ({ children }: { children: ReactNode }) => {
     setDesktopSidebarCollapsed(!desktopSidebarCollapsed);
   };
 
-  // Send from header input
-  const handleTopInputSend = async () => {
-    if (topInput.trim() && send) {
-      try {
-        await send(topInput.trim());
-        setTopInput('');
-        setIsChatOpen(true);
-      } catch (error) {
-        console.error("Error sending message:", error);
-      }
-    }
+  const toggleChat = () => {
+    setIsChatOpen(!isChatOpen);
   };
 
   // Loading state for user (optional, depends if you want to delay render)

--- a/components/ui/WeatherWidget.tsx
+++ b/components/ui/WeatherWidget.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import React, { useState, useEffect } from 'react';
+import { Cloud, Sun, CloudRain, CloudSnow, Wind, Thermometer } from 'lucide-react';
+
+interface WeatherData {
+  temperature: number;
+  condition: string;
+  icon: string;
+  location: string;
+}
+
+const WeatherWidget: React.FC = () => {
+  const [weather, setWeather] = useState<WeatherData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const getWeatherIcon = (condition: string) => {
+    const conditionLower = condition.toLowerCase();
+    if (conditionLower.includes('sun') || conditionLower.includes('clear')) {
+      return <Sun className="w-4 h-4" />;
+    } else if (conditionLower.includes('cloud')) {
+      return <Cloud className="w-4 h-4" />;
+    } else if (conditionLower.includes('rain')) {
+      return <CloudRain className="w-4 h-4" />;
+    } else if (conditionLower.includes('snow')) {
+      return <CloudSnow className="w-4 h-4" />;
+    } else if (conditionLower.includes('wind')) {
+      return <Wind className="w-4 h-4" />;
+    }
+    return <Thermometer className="w-4 h-4" />;
+  };
+
+  const fetchWeather = async (lat: number, lon: number) => {
+    try {
+      setLoading(true);
+      setError(null);
+      
+      // Using OpenWeatherMap API (you'll need to add your API key to environment variables)
+      const response = await fetch(
+        `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&appid=${process.env.NEXT_PUBLIC_OPENWEATHER_API_KEY}&units=metric`
+      );
+      
+      if (!response.ok) {
+        throw new Error('Weather data unavailable');
+      }
+      
+      const data = await response.json();
+      
+      setWeather({
+        temperature: Math.round(data.main.temp),
+        condition: data.weather[0].main,
+        icon: data.weather[0].icon,
+        location: data.name
+      });
+    } catch (err) {
+      setError('Weather unavailable');
+      console.error('Weather fetch error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          fetchWeather(position.coords.latitude, position.coords.longitude);
+        },
+        (error) => {
+          console.error('Geolocation error:', error);
+          setError('Location unavailable');
+        }
+      );
+    } else {
+      setError('Geolocation not supported');
+    }
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-neutral-100 dark:bg-neutral-800">
+        <div className="animate-spin w-4 h-4 border-2 border-primary-500 border-t-transparent rounded-full"></div>
+        <span className="text-xs text-neutral-600 dark:text-neutral-400">Loading weather...</span>
+      </div>
+    );
+  }
+
+  if (error || !weather) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-neutral-100 dark:bg-neutral-800">
+        <Thermometer className="w-4 h-4 text-neutral-500" />
+        <span className="text-xs text-neutral-600 dark:text-neutral-400">Weather unavailable</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors">
+      {getWeatherIcon(weather.condition)}
+      <span className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+        {weather.temperature}°C
+      </span>
+    </div>
+  );
+};
+
+export default WeatherWidget;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -415,3 +415,30 @@
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
+
+/* Chat side modal animations */
+@keyframes slideInRight {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideOutRight {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
+.animate-slide-in-right {
+  animation: slideInRight 0.3s ease-out;
+}
+
+.animate-slide-out-right {
+  animation: slideOutRight 0.3s ease-out;
+}


### PR DESCRIPTION
Move chat widget to a responsive side modal and add a weather widget to the header, improving UI and fixing chat input overflow.

The chat widget was previously in the header, taking up significant space and not being mobile-friendly. This PR relocates it to a side modal for a cleaner header and better user experience, especially on mobile. Additionally, a weather widget was added as requested. A subsequent fix addressed an overflow issue in the chat widget, making the input field accessible.

---

[Open in Web](https://www.cursor.com/agents?id=bc-37cac634-a3cf-4a50-8709-a9b8204b36a8) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-37cac634-a3cf-4a50-8709-a9b8204b36a8)