### PR TITLE
Add alpha test banner to landing page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -76,6 +76,44 @@ function LandingPage() {
       </Head>
 
       <main className="bg-gradient-to-br from-primary-50 via-white to-slate-100 dark:from-[#202241] dark:via-[#181928] dark:to-[#10111a] min-h-screen">
+        {/* Alpha Testing Banner */}
+        <div className="bg-gradient-to-r from-[#00C9A7] to-[#00B396] text-white relative overflow-hidden">
+          <div className="absolute inset-0 bg-black/5"></div>
+          <div className="relative max-w-6xl mx-auto px-6 py-4">
+            <div className="flex flex-col md:flex-row items-center justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <div className="flex items-center gap-2">
+                  <Image 
+                    src="/flocat_flohub.png" 
+                    alt="FloCat" 
+                    width={32} 
+                    height={32} 
+                    className="rounded-full bg-white/20 p-1" 
+                  />
+                  <div className="bg-[#FF6B6B] text-white px-3 py-1 rounded-full text-sm font-semibold">
+                    ALPHA
+                  </div>
+                </div>
+                <div>
+                  <p className="font-semibold text-lg">Welcome to FloHub Alpha! 🚀</p>
+                  <p className="text-sm opacity-90">
+                    You're testing the future of productivity. <strong>Completely free</strong> during alpha — help us perfect your workflow!
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 text-sm">
+                <div className="hidden sm:block text-right opacity-90">
+                  <p>Found a bug? Have feedback?</p>
+                  <p>FloCat is listening! 😺</p>
+                </div>
+                <Link href="/feedback" className="bg-white/20 hover:bg-white/30 transition-colors px-4 py-2 rounded-xl font-medium border border-white/30">
+                  Share Feedback
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+
         {/* Hero */}
         <div className="relative flex flex-col-reverse md:flex-row items-center max-w-6xl mx-auto px-6 py-20">
           {/* Hero Left */}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add an alpha testing banner to the landing page to inform users it's free during testing and encourage feedback, adhering to branding guidelines.

---

[Open in Web](https://cursor.com/agents?id=bc-19f28248-3fd5-41f2-8b8a-257718c311a9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-19f28248-3fd5-41f2-8b8a-257718c311a9) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)