### PR TITLE
Fix widget showing zero pending tasks

### DIFF
--- a/components/widgets/AtAGlanceWidget.tsx
+++ b/components/widgets/AtAGlanceWidget.tsx
@@ -496,11 +496,11 @@ const AtAGlanceWidget = () => {
       const [tasksData, notesData, meetingsData, habitsData, habitCompletionsData] = await Promise.allSettled(fetchPromises);
 
       // Process results with fallbacks
-      const tasks = tasksData.status === 'fulfilled' ? tasksData.value : { tasks: [] };
-      const notes = notesData.status === 'fulfilled' ? notesData.value : { notes: [] };
-      const meetings = meetingsData.status === 'fulfilled' ? meetingsData.value : { meetings: [] };
-      const habits = habitsData.status === 'fulfilled' ? habitsData.value : { habits: [] };
-      const habitCompletions = habitCompletionsData.status === 'fulfilled' ? habitCompletionsData.value : { completions: [] };
+      const tasks = tasksData.status === 'fulfilled' ? tasksData.value || [] : [];
+      const notes = notesData.status === 'fulfilled' ? notesData.value.notes || [] : [];
+      const meetings = meetingsData.status === 'fulfilled' ? meetingsData.value.meetingNotes || [] : [];
+      const habits = habitsData.status === 'fulfilled' ? habitsData.value || [] : [];
+      const habitCompletions = habitCompletionsData.status === 'fulfilled' ? habitCompletionsData.value || [] : [];
 
       // Process events data with timezone conversion (using shared calendar events)
       const eventsInUserTimezone = calendarEvents.map((event: CalendarEvent) => {
@@ -575,10 +575,10 @@ const AtAGlanceWidget = () => {
 
       // Generate widget content
       const widgetContent = generateDashboardWidget(
-        tasks.tasks || [],
+        tasks || [],
         upcomingEventsForPrompt,
-        habits.habits || [],
-        habitCompletions.completions || [],
+                  habits || [],
+          habitCompletions || [],
         user.name || user.email,
         userTimezone
       );
@@ -586,11 +586,11 @@ const AtAGlanceWidget = () => {
       setWidgetData({
         content: widgetContent,
         events: upcomingEventsForPrompt,
-        tasks: tasks.tasks || [],
-        notes: notes.notes || [],
-        meetings: meetings.meetings || [],
-        habits: habits.habits || [],
-        habitCompletions: habitCompletions.completions || [],
+        tasks: tasks || [],
+                  notes: notes || [],
+          meetings: meetings || [],
+          habits: habits || [],
+                  habitCompletions: habitCompletions || [],
         lastUpdated: new Date()
       });
 

--- a/components/widgets/SmartAtAGlanceWidget.tsx
+++ b/components/widgets/SmartAtAGlanceWidget.tsx
@@ -330,11 +330,11 @@ const SmartAtAGlanceWidget = () => {
       const [tasksData, notesData, meetingsData, habitsData, habitCompletionsData] = await Promise.allSettled(fetchPromises);
 
       // Process results with fallbacks
-      const tasks = tasksData.status === 'fulfilled' ? tasksData.value.tasks || [] : [];
+      const tasks = tasksData.status === 'fulfilled' ? tasksData.value || [] : [];
       const notes = notesData.status === 'fulfilled' ? notesData.value.notes || [] : [];
-      const meetings = meetingsData.status === 'fulfilled' ? meetingsData.value.meetings || [] : [];
-      const habits = habitsData.status === 'fulfilled' ? habitsData.value.habits || [] : [];
-      const habitCompletions = habitCompletionsData.status === 'fulfilled' ? habitCompletionsData.value.completions || [] : [];
+      const meetings = meetingsData.status === 'fulfilled' ? meetingsData.value.meetingNotes || [] : [];
+      const habits = habitsData.status === 'fulfilled' ? habitsData.value || [] : [];
+      const habitCompletions = habitCompletionsData.status === 'fulfilled' ? habitCompletionsData.value || [] : [];
 
       // Debug logging
       console.log('SmartAtAGlanceWidget Debug:', {
@@ -346,6 +346,23 @@ const SmartAtAGlanceWidget = () => {
           done: t.done,
           status: t.status 
         })).slice(0, 5)
+      });
+
+      // Debug task filtering specifically
+      const completedTasks = tasks.filter((t: any) => t.done);
+      const incompleteTasks = tasks.filter((t: any) => !t.done);
+      console.log('SmartAtAGlanceWidget Task Count Debug:', {
+        totalTasksReceived: tasks.length,
+        completedTasksCount: completedTasks.length,
+        incompleteTasksCount: incompleteTasks.length,
+        completedTasksPreview: completedTasks.slice(0, 2).map((t: any) => ({
+          text: t.text?.substring(0, 20),
+          done: t.done
+        })),
+        incompleteTasksPreview: incompleteTasks.slice(0, 2).map((t: any) => ({
+          text: t.text?.substring(0, 20),
+          done: t.done
+        }))
       });
 
       // Analyze and set data


### PR DESCRIPTION
Corrected data structure handling in AtAGlance widgets to match API responses, resolving incorrect task and other item counts.

The `SmartAtAGlanceWidget` and `AtAGlanceWidget` components expected task, meeting, and habit data to be nested within specific properties (e.g., `tasks.tasks`, `meetings.meetings`, `habits.habits`), but the respective APIs returned the data as direct arrays or with different property names (e.g., `meetingNotes`). This mismatch led to the widgets failing to correctly process and display counts for pending tasks, meetings, and habits.

---

[Open in Web](https://cursor.com/agents?id=bc-75e657f9-1193-48de-a35c-bb0e073709d2) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-75e657f9-1193-48de-a35c-bb0e073709d2) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)