### PR TITLE
Ensure privacy and terms pages are public

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -19,7 +19,7 @@ export async function middleware(request: NextRequest) {
   }
 
   // Skip middleware for other public paths.
-  const publicPaths = ['/login', '/register', '/api/auth'];
+  const publicPaths = ['/login', '/register', '/api/auth', '/privacy', '/terms'];
   if (publicPaths.some(path => pathname.startsWith(path))) {
     return NextResponse.next();
   }
@@ -57,6 +57,6 @@ export const config = {
      * - public folder
      * - auth routes (login, register, etc)
      */
-    '/((?!_next/static|_next/image|favicon.ico|public|login|register|api/auth).*)',
+    '/((?!_next/static|_next/image|favicon.ico|public|login|register|api/auth|privacy|terms).*)',
   ],
 };

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   description: 'Privacy Policy for FloHub - Learn how we collect, use, and protect your data.',
 };
 
-export default function PrivacyPolicy() {
+function PrivacyPolicy() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-neutral-50 to-neutral-100 dark:from-neutral-900 dark:to-neutral-800">
       <div className="max-w-4xl mx-auto px-6 py-12">
@@ -225,3 +225,8 @@ export default function PrivacyPolicy() {
     </div>
   );
 }
+
+// Mark this page as public (no authentication required)
+PrivacyPolicy.auth = false;
+
+export default PrivacyPolicy;

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   description: 'Terms of Service for FloHub - Understand our terms and conditions of use.',
 };
 
-export default function TermsOfService() {
+function TermsOfService() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-neutral-50 to-neutral-100 dark:from-neutral-900 dark:to-neutral-800">
       <div className="max-w-4xl mx-auto px-6 py-12">
@@ -214,3 +214,8 @@ export default function TermsOfService() {
     </div>
   );
 }
+
+// Mark this page as public (no authentication required)
+TermsOfService.auth = false;
+
+export default TermsOfService;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Make privacy and terms pages publicly accessible to ensure they are not behind login or authentication.

---

[Open in Web](https://cursor.com/agents?id=bc-ffd3da42-13c1-4861-8c20-1345ac325868) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ffd3da42-13c1-4861-8c20-1345ac325868) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)