### PR TITLE
Fix duplicate menu bar on user management

### DIFF
--- a/pages/dashboard/admin.tsx
+++ b/pages/dashboard/admin.tsx
@@ -1,7 +1,6 @@
 import { useUser } from "@/lib/hooks/useUser";
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import Layout from '@/components/ui/Layout';
 import AdminAnalytics from '@/components/admin/AdminAnalytics';
 import UserManagement from '@/components/admin/UserManagement';
 import Head from 'next/head';
@@ -19,11 +18,9 @@ const [activeTab, setActiveTab] = useState<'users' | 'analytics'>('users');
   // Handle loading state
   if (status === 'unauthenticated') {
     return (
-      <Layout>
-        <div className="flex items-center justify-center min-h-screen">
-          <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary-500"></div>
-        </div>
-      </Layout>
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary-500"></div>
+      </div>
     );
   }
 
@@ -41,21 +38,19 @@ const [activeTab, setActiveTab] = useState<'users' | 'analytics'>('users');
   // If not authorized, show a message (will redirect via useEffect)
   if (!isAuthorized) {
     return (
-      <Layout>
-        <div className="flex items-center justify-center min-h-screen">
-          <div className="text-center">
-            <h1 className="text-xl font-bold mb-2">Unauthorized Access</h1>
-            <p>You don't have permission to view this page.</p>
-            <p>Redirecting to dashboard...</p>
-          </div>
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <h1 className="text-xl font-bold mb-2">Unauthorized Access</h1>
+          <p>You don't have permission to view this page.</p>
+          <p>Redirecting to dashboard...</p>
         </div>
-      </Layout>
+      </div>
     );
   }
 
   // If authorized, render the admin content
   return (
-    <Layout>
+    <>
       <Head>
         <title>Admin Dashboard | FlowHub</title>
       </Head>
@@ -98,6 +93,6 @@ const [activeTab, setActiveTab] = useState<'users' | 'analytics'>('users');
       <div className="px-4">
         {activeTab === 'users' ? <UserManagement /> : <AdminAnalytics />}
       </div>
-    </Layout>
+    </>
   );
 }


### PR DESCRIPTION
Remove redundant Layout wrapper from admin page to fix duplicate menu bar.

The admin page was explicitly using `<Layout>` while `_app.tsx` already wraps all authenticated pages with `MainLayout` (which includes `Layout`), leading to a double rendering of the menu bar.

---

[Open in Web](https://cursor.com/agents?id=bc-8e06f5f6-c8f6-4ef1-81c0-7cce770d05d9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-8e06f5f6-c8f6-4ef1-81c0-7cce770d05d9) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)