### PR TITLE
Fix duplicate menus in calendar, habits, and journal

### DIFF
--- a/components/ui/Layout.tsx
+++ b/components/ui/Layout.tsx
@@ -95,12 +95,10 @@ const Layout = ({ children }: { children: ReactNode }) => {
       {/* sidebar */}
       <aside
         className={`
-          bg-[var(--surface)] shadow-glass z-30 transition-all duration-300 ease-in-out
-          fixed inset-y-0 left-0 transform
-          ${mobileSidebarOpen ? 'translate-x-0' : '-translate-x-full'}
-          md:static md:translate-x-0 md:shadow-none md:transform-none
+          bg-[var(--surface)] shadow-glass z-30 transform transition-all duration-300 ease-in-out
+          ${mobileSidebarOpen ? 'fixed inset-y-0 left-0 translate-x-0' : 'fixed inset-y-0 left-0 -translate-x-full'}
+          md:static md:translate-x-0 md:shadow-none
           ${desktopSidebarCollapsed ? 'md:w-20' : 'md:w-64'}
-          w-64 md:w-auto
           border-r border-neutral-200 dark:border-neutral-700 flex flex-col
         `}
       >

--- a/components/ui/Layout.tsx
+++ b/components/ui/Layout.tsx
@@ -95,10 +95,12 @@ const Layout = ({ children }: { children: ReactNode }) => {
       {/* sidebar */}
       <aside
         className={`
-          bg-[var(--surface)] shadow-glass z-30 transform transition-all duration-300 ease-in-out
-          ${mobileSidebarOpen ? 'fixed inset-y-0 left-0 translate-x-0' : 'fixed inset-y-0 left-0 -translate-x-full'}
-          md:static md:translate-x-0 md:shadow-none
+          bg-[var(--surface)] shadow-glass z-30 transition-all duration-300 ease-in-out
+          fixed inset-y-0 left-0 transform
+          ${mobileSidebarOpen ? 'translate-x-0' : '-translate-x-full'}
+          md:static md:translate-x-0 md:shadow-none md:transform-none
           ${desktopSidebarCollapsed ? 'md:w-20' : 'md:w-64'}
+          w-64 md:w-auto
           border-r border-neutral-200 dark:border-neutral-700 flex flex-col
         `}
       >

--- a/pages/calendar/index.tsx
+++ b/pages/calendar/index.tsx
@@ -380,27 +380,33 @@ const CalendarPage = () => {
   // Simplified loading state management
   const hasEvents = events && events.length > 0;
 
-  if (!user || status === 'unauthenticated') {
-    return (
-      <MainLayout requiresAuth={true}>
+  const viewTabs = [
+    { id: 'day', label: 'Day', icon: CalendarIcon },
+    { id: 'week', label: 'Week', icon: ViewColumnsIcon },
+    { id: 'month', label: 'Month', icon: CalendarDaysIcon },
+    { id: 'agenda', label: 'Agenda', icon: ListBulletIcon },
+    { id: 'timeline', label: 'Timeline', icon: ChartBarIcon }
+  ];
+
+  return (
+    <MainLayout requiresAuth={true}>
+      <Head>
+        <title>Calendar | FlowHub</title>
+        <meta name="description" content="Manage your events and schedule with FlowHub's intelligent calendar" />
+      </Head>
+      
+      {/* Unauthenticated state */}
+      {(!user || status === 'unauthenticated') && (
         <div className="flex items-center justify-center min-h-screen">
           <div className="text-center">
             <div className="text-6xl mb-4">🔒</div>
             <p className="text-grey-tint">Please sign in to access your calendar.</p>
           </div>
         </div>
-      </MainLayout>
-    );
-  }
+      )}
 
-  // Show skeleton only during initial loading, not during background refreshes
-  if (isLoading && !hasEvents && !fetchError) {
-    return (
-      <MainLayout requiresAuth={true}>
-        <Head>
-          <title>Calendar | FlowHub</title>
-          <meta name="description" content="Manage your events and schedule with FlowHub's intelligent calendar" />
-        </Head>
+      {/* Loading state */}
+      {(isLoading && !hasEvents && !fetchError && user && status === 'authenticated') && (
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           {/* Header */}
           <div className="mb-8">
@@ -467,18 +473,10 @@ const CalendarPage = () => {
             </div>
           </div>
         </div>
-      </MainLayout>
-    );
-  }
+      )}
 
-  // Handle persistent errors that should show error state
-  if ((settingsError || fetchError) && !isLoading && !hasEvents) {
-    return (
-      <MainLayout requiresAuth={true}>
-        <Head>
-          <title>Calendar | FlowHub</title>
-          <meta name="description" content="Manage your events and schedule with FlowHub's intelligent calendar" />
-        </Head>
+      {/* Error state */}
+      {((settingsError || fetchError) && !isLoading && !hasEvents && user && status === 'authenticated') && (
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 p-6 rounded-2xl shadow-xl">
             <h3 className="font-heading font-bold text-lg mb-3">Calendar Load Error</h3>
@@ -510,25 +508,10 @@ const CalendarPage = () => {
             </div>
           </div>
         </div>
-      </MainLayout>
-    );
-  }
+      )}
 
-  const viewTabs = [
-    { id: 'day', label: 'Day', icon: CalendarIcon },
-    { id: 'week', label: 'Week', icon: ViewColumnsIcon },
-    { id: 'month', label: 'Month', icon: CalendarDaysIcon },
-    { id: 'agenda', label: 'Agenda', icon: ListBulletIcon },
-    { id: 'timeline', label: 'Timeline', icon: ChartBarIcon }
-  ];
-
-  return (
-    <MainLayout requiresAuth={true}>
-      <Head>
-        <title>Calendar | FlowHub</title>
-        <meta name="description" content="Manage your events and schedule with FlowHub's intelligent calendar" />
-      </Head>
-      
+      {/* Main calendar content */}
+      {(user && status === 'authenticated' && !(isLoading && !hasEvents && !fetchError) && !((settingsError || fetchError) && !isLoading && !hasEvents)) && (
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
         {/* Header Section */}
         <div className="flex items-center justify-between mb-6">
@@ -1329,6 +1312,7 @@ const CalendarPage = () => {
           }
         />
       </div>
+      )}
     </MainLayout>
   );
 };

--- a/pages/dashboard/journal.tsx
+++ b/pages/dashboard/journal.tsx
@@ -36,33 +36,7 @@ export default function JournalPage() {
   const status = user ? "authenticated" : "unauthenticated";
   const router = useRouter();
 
-  // Handle loading state
-  if (status === 'unauthenticated') {
-    return (
-      <MainLayout requiresAuth={true}>
-        <div className="flex items-center justify-center min-h-screen">
-          <div className="animate-pulse text-center">
-            <div className="w-16 h-16 bg-primary-200 dark:bg-primary-800 rounded-full mx-auto mb-4"></div>
-            <p className="text-grey-tint">Loading your journal...</p>
-          </div>
-        </div>
-      </MainLayout>
-    );
-  }
-
-  // Handle unauthenticated state
-  if (status !== 'authenticated' || !user) {
-    return (
-      <MainLayout requiresAuth={true}>
-        <div className="flex items-center justify-center min-h-screen">
-          <div className="text-center">
-            <div className="text-6xl mb-4">🔒</div>
-            <p className="text-grey-tint">Please sign in to access your journal.</p>
-          </div>
-        </div>
-      </MainLayout>
-    );
-  }
+  // Handle loading state and authentication logic inside the single MainLayout wrapper
 
   const [selectedDate, setSelectedDate] = useState<string>("");
   const [isMobile, setIsMobile] = useState(false);
@@ -239,6 +213,28 @@ export default function JournalPage() {
         <meta name="description" content="Capture your thoughts, track moods, and reflect on your journey with FlowHub's intelligent journal" />
       </Head>
       
+      {/* Loading state */}
+      {status === 'unauthenticated' && (
+        <div className="flex items-center justify-center min-h-screen">
+          <div className="animate-pulse text-center">
+            <div className="w-16 h-16 bg-primary-200 dark:bg-primary-800 rounded-full mx-auto mb-4"></div>
+            <p className="text-grey-tint">Loading your journal...</p>
+          </div>
+        </div>
+      )}
+
+      {/* Unauthenticated state */}
+      {(status !== 'authenticated' || !user) && status !== 'unauthenticated' && (
+        <div className="flex items-center justify-center min-h-screen">
+          <div className="text-center">
+            <div className="text-6xl mb-4">🔒</div>
+            <p className="text-grey-tint">Please sign in to access your journal.</p>
+          </div>
+        </div>
+      )}
+
+      {/* Main journal content */}
+      {status === 'authenticated' && user && (
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
         {/* Header Section */}
         <div className="flex items-center justify-between mb-6">
@@ -546,6 +542,7 @@ export default function JournalPage() {
           </div>
         )}
       </div>
+      )}
     </MainLayout>
   );
 }


### PR DESCRIPTION
Consolidate `MainLayout` wrappers to fix duplicate navigation menus on Calendar and Journal pages.

The Calendar and Journal pages had multiple `MainLayout` components rendered due to separate conditional return statements for different states (loading, unauthenticated, error, main content). Each `MainLayout` includes the navigation sidebar, causing the duplicate menus. This PR refactors these pages to use a single `MainLayout` wrapper with conditional rendering of content inside.

---

[Open in Web](https://cursor.com/agents?id=bc-bc339f09-0951-462f-9049-1c6f6018dd9a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-bc339f09-0951-462f-9049-1c6f6018dd9a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)