### PR TITLE
Remove duplicate menu bars from calendar, journal, and habits

### DIFF
--- a/pages/calendar/index.tsx
+++ b/pages/calendar/index.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import useSWR from 'swr';
 import { useUser } from "@/lib/hooks/useUser";
 import Head from 'next/head';
-import MainLayout from "@/components/ui/MainLayout";
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, isSameDay, parseISO, addMonths, subMonths, getDay, startOfWeek, endOfWeek, addDays, isToday, isSameMonth, startOfDay, endOfDay, addWeeks, subWeeks, isWithinInterval } from 'date-fns';
 import { CalendarEvent, CalendarSettings } from '@/types/calendar';
 import { CalendarEventForm } from '@/components/calendar/CalendarEventForm';
@@ -382,21 +381,19 @@ const CalendarPage = () => {
 
   if (!user || status === 'unauthenticated') {
     return (
-      <MainLayout requiresAuth={true}>
-        <div className="flex items-center justify-center min-h-screen">
-          <div className="text-center">
-            <div className="text-6xl mb-4">🔒</div>
-            <p className="text-grey-tint">Please sign in to access your calendar.</p>
-          </div>
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <div className="text-6xl mb-4">🔒</div>
+          <p className="text-grey-tint">Please sign in to access your calendar.</p>
         </div>
-      </MainLayout>
+      </div>
     );
   }
 
   // Show skeleton only during initial loading, not during background refreshes
   if (isLoading && !hasEvents && !fetchError) {
     return (
-      <MainLayout requiresAuth={true}>
+      <>
         <Head>
           <title>Calendar | FlowHub</title>
           <meta name="description" content="Manage your events and schedule with FlowHub's intelligent calendar" />
@@ -467,14 +464,14 @@ const CalendarPage = () => {
             </div>
           </div>
         </div>
-      </MainLayout>
+      </>
     );
   }
 
   // Handle persistent errors that should show error state
   if ((settingsError || fetchError) && !isLoading && !hasEvents) {
     return (
-      <MainLayout requiresAuth={true}>
+      <>
         <Head>
           <title>Calendar | FlowHub</title>
           <meta name="description" content="Manage your events and schedule with FlowHub's intelligent calendar" />
@@ -510,7 +507,7 @@ const CalendarPage = () => {
             </div>
           </div>
         </div>
-      </MainLayout>
+      </>
     );
   }
 
@@ -523,7 +520,7 @@ const CalendarPage = () => {
   ];
 
   return (
-    <MainLayout requiresAuth={true}>
+    <>
       <Head>
         <title>Calendar | FlowHub</title>
         <meta name="description" content="Manage your events and schedule with FlowHub's intelligent calendar" />
@@ -1329,7 +1326,7 @@ const CalendarPage = () => {
           }
         />
       </div>
-    </MainLayout>
+    </>
   );
 };
 

--- a/pages/dashboard/journal.tsx
+++ b/pages/dashboard/journal.tsx
@@ -7,7 +7,6 @@ import useSWR from "swr";
 import { getCurrentDate, formatDate } from "@/lib/dateUtils";
 import axios from "axios";
 import { useUser } from "@/lib/hooks/useUser";
-import MainLayout from "@/components/ui/MainLayout";
 // Import journal components 
 import TodayEntry from "@/components/journal/TodayEntry";
 import MoodTracker from "@/components/journal/MoodTracker";
@@ -39,28 +38,24 @@ export default function JournalPage() {
   // Handle loading state
   if (status === 'unauthenticated') {
     return (
-      <MainLayout requiresAuth={true}>
-        <div className="flex items-center justify-center min-h-screen">
-          <div className="animate-pulse text-center">
-            <div className="w-16 h-16 bg-primary-200 dark:bg-primary-800 rounded-full mx-auto mb-4"></div>
-            <p className="text-grey-tint">Loading your journal...</p>
-          </div>
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="animate-pulse text-center">
+          <div className="w-16 h-16 bg-primary-200 dark:bg-primary-800 rounded-full mx-auto mb-4"></div>
+          <p className="text-grey-tint">Loading your journal...</p>
         </div>
-      </MainLayout>
+      </div>
     );
   }
 
   // Handle unauthenticated state
   if (status !== 'authenticated' || !user) {
     return (
-      <MainLayout requiresAuth={true}>
-        <div className="flex items-center justify-center min-h-screen">
-          <div className="text-center">
-            <div className="text-6xl mb-4">🔒</div>
-            <p className="text-grey-tint">Please sign in to access your journal.</p>
-          </div>
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <div className="text-6xl mb-4">🔒</div>
+          <p className="text-grey-tint">Please sign in to access your journal.</p>
         </div>
-      </MainLayout>
+      </div>
     );
   }
 
@@ -233,7 +228,7 @@ export default function JournalPage() {
   ];
 
   return (
-    <MainLayout requiresAuth={true}>
+    <>
       <Head>
         <title>Journal | FlowHub</title>
         <meta name="description" content="Capture your thoughts, track moods, and reflect on your journey with FlowHub's intelligent journal" />
@@ -546,6 +541,6 @@ export default function JournalPage() {
           </div>
         )}
       </div>
-    </MainLayout>
+    </>
   );
 }

--- a/pages/habit-tracker.tsx
+++ b/pages/habit-tracker.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import Head from 'next/head';
 import HabitTrackerMain from "@/components/habit-tracker/HabitTrackerMain";
-import MainLayout from "@/components/ui/MainLayout";
 
 const HabitTrackerPage = () => {
   return (
-    <MainLayout requiresAuth={true}>
+    <>
       <Head>
         <title>Habit Tracker | FlowHub</title>
         <meta name="description" content="Track and build lasting habits with FlowHub's intelligent habit tracker and FloCat insights" />
       </Head>
       
       <HabitTrackerMain />
-    </MainLayout>
+    </>
   );
 };
 


### PR DESCRIPTION
Remove duplicate `MainLayout` wrappers from calendar, journal, and habit tracker pages to fix double menu bars.

---

[Open in Web](https://cursor.com/agents?id=bc-637f6194-5c37-4395-8168-ca46357fc583) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-637f6194-5c37-4395-8168-ca46357fc583) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)