### PR TITLE
Fix PWA banner dismissibility issue

### DIFF
--- a/components/ui/PWAInstallPrompt.tsx
+++ b/components/ui/PWAInstallPrompt.tsx
@@ -1,14 +1,14 @@
 import { usePWA } from '@/utils/usePWA';
 
 export default function PWAInstallPrompt() {
-  const { isInstallable, installApp } = usePWA();
+  const { isInstallable, installApp, dismissInstallPrompt } = usePWA();
 
   const handleInstallClick = async () => {
     await installApp();
   };
 
   const handleDismiss = () => {
-    // This will be handled by the hook
+    dismissInstallPrompt();
   };
 
   if (!isInstallable) return null;

--- a/pages/api/feedback.ts
+++ b/pages/api/feedback.ts
@@ -138,7 +138,7 @@ export default async function handler(
       if (status === "backlog") {
         await db.insert(backlog).values({ 
           originalId: id, 
-          text: existingFeedback.description || existingFeedback.title, 
+          text: existingFeedback.description || existingFeedback.title || 'No description provided', 
           createdAt: new Date(), 
           userId: userEmail 
         });


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix PWA banner not being dismissible by implementing persistent dismiss functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-7580ee88-705c-4042-837f-ed1b8445802d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7580ee88-705c-4042-837f-ed1b8445802d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>