### PR TITLE
Adjust mobile sidebar alignment and width

### DIFF
--- a/components/ui/Layout.tsx
+++ b/components/ui/Layout.tsx
@@ -237,11 +237,11 @@ const Layout = ({ children }: { children: ReactNode }) => {
       <aside
         className={`
           bg-[var(--surface)] shadow-glass z-30 transform transition-all duration-300 ease-in-out
-          ${mobileSidebarOpen ? 'fixed inset-y-0 left-0 translate-x-0 w-64' : 'fixed inset-y-0 left-0 -translate-x-full w-64'}
-          md:static md:translate-x-0 md:shadow-none
+          ${mobileSidebarOpen ? 'fixed inset-y-0 left-0 translate-x-0 w-4/5 sm:w-3/5' : 'fixed inset-y-0 left-0 -translate-x-full w-4/5 sm:w-3/5'}
+          md:static md:translate-x-0 md:shadow-none md:w-64
           ${desktopSidebarCollapsed ? 'md:w-20' : 'md:w-64'}
           border-r border-neutral-200 dark:border-neutral-700 flex flex-col
-          max-h-screen
+          h-screen
         `}
       >
         {/* Header */}
@@ -266,8 +266,8 @@ const Layout = ({ children }: { children: ReactNode }) => {
           </button>
         </div>
         
-        {/* Main navigation - height-responsive */}
-        <nav className="flex-1 overflow-y-auto min-h-0 flex flex-col justify-start sidebar-nav">
+        {/* Main navigation - mobile no scroll, desktop with scroll */}
+        <nav className="flex-1 md:overflow-y-auto md:min-h-0 flex flex-col justify-start sidebar-nav">
           <div className="space-y-1 p-3 md:p-4">
             {navigationItems.map((item) => (
               <Link

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -178,6 +178,19 @@
     --sidebar-nav-spacing: 0.1875rem;
     --sidebar-nav-padding: 0.75rem 1rem;
   }
+  
+  /* Mobile sidebar specific styles */
+  .sidebar-nav {
+    overflow-y: visible !important;
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: space-between !important;
+    height: 100% !important;
+  }
+  
+  .sidebar-nav > div {
+    flex-shrink: 0;
+  }
 }
 
 /* Very small mobile devices */


### PR DESCRIPTION
Make the mobile sidebar responsive, left-aligned, and ensure all items are visible without scrolling.

---
<a href="https://cursor.com/background-agent?bcId=bc-4acc56c1-7a43-40d7-853b-3591f43a1857">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4acc56c1-7a43-40d7-853b-3591f43a1857">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>