### PR TITLE
Fix timezone not saving in settings

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -111,7 +111,7 @@ export const userSettings = pgTable("user_settings", {
   activeWidgets: text("active_widgets").array(),
   hiddenWidgets: text("hidden_widgets").array(),
   calendarSources: jsonb("calendar_sources"),
-  timezone: varchar("timezone", { length: 50 }),
+  timezone: varchar("timezone", { length: 50 }).notNull().default('UTC'),
   tags: text("tags").array(),
   widgets: text("widgets").array(),
   calendarSettings: jsonb("calendar_settings"),

--- a/pages/dashboard/settings.tsx
+++ b/pages/dashboard/settings.tsx
@@ -26,7 +26,7 @@ const SettingsPage = () => {
     defaultView: "today",
     customRange: { start: "", end: "" },
     globalTags: [],
-    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    timezone: undefined, // Don't set initial timezone - let API response populate it
     tags: [],
     widgets: [],
     calendarSources: [],
@@ -44,6 +44,7 @@ const SettingsPage = () => {
   const [activeTab, setActiveTab] = useState("general");
   const [newPersonalityKeyword, setNewPersonalityKeyword] = useState("");
   const [isSaving, setIsSaving] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   // Define tabs with icons and improved structure
   const tabs = [
@@ -94,9 +95,18 @@ const SettingsPage = () => {
 
   useEffect(() => {
     if (user?.primaryEmail) {
+      setIsLoading(true);
       fetch(`/api/userSettings?userId=${user.primaryEmail}`)
         .then((res) => res.json())
-        .then((data) => setSettings(data));
+        .then((data) => {
+          console.log('Settings loaded:', data);
+          setSettings(data);
+          setIsLoading(false);
+        })
+        .catch((error) => {
+          console.error('Error loading settings:', error);
+          setIsLoading(false);
+        });
     }
   }, [user]);
 
@@ -148,6 +158,15 @@ const SettingsPage = () => {
   };
 
   const renderTabContent = () => {
+    if (isLoading) {
+      return (
+        <div className="flex items-center justify-center py-12">
+          <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary-500 border-t-transparent"></div>
+          <span className="ml-3 text-neutral-600 dark:text-neutral-400">Loading settings...</span>
+        </div>
+      );
+    }
+
     switch (activeTab) {
       case "general":
         return <TimezoneSettings settings={settings} onSettingsChange={handleSettingsChange} />;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix timezone setting reverting to UTC by correcting initial state and adding a loading indicator.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The settings page was initially displaying the browser's timezone before the API call for saved settings completed, creating a perceived data loss. This PR ensures the component waits for the API response and displays a loading state. Additionally, the `timezone` column in `user_settings` is now `NOT NULL` with a `DEFAULT 'UTC'` to prevent null values, requiring a manual database migration.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e6b1bff-d538-4b77-a86a-a91ff33d5c04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e6b1bff-d538-4b77-a86a-a91ff33d5c04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>