### PR TITLE
Align sidebar header height with page header

### DIFF
--- a/components/ui/Layout.tsx
+++ b/components/ui/Layout.tsx
@@ -254,7 +254,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
         }}
       >
         {/* Header */}
-        <div className={`py-[26px] px-4 border-b border-neutral-200 dark:border-neutral-700 flex items-center ${desktopSidebarCollapsed ? 'justify-center' : 'justify-between'} flex-shrink-0`}>
+        <div className={`p-4 border-b border-neutral-200 dark:border-neutral-700 flex items-center ${desktopSidebarCollapsed ? 'justify-center' : 'justify-between'} flex-shrink-0`}>
           {!desktopSidebarCollapsed && (
             <Image
               src="/FloHub_Logo_Transparent.png"


### PR DESCRIPTION
Adjust sidebar header padding to match the page header height and fix misalignment.

---
<a href="https://cursor.com/background-agent?bcId=bc-7331a3ae-e12f-49a9-8ca5-bd6e2d78cf6c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7331a3ae-e12f-49a9-8ca5-bd6e2d78cf6c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>