### PR TITLE
Fix notes page scrolling and dropdown

### DIFF
--- a/components/journal/RichTextEditor.tsx
+++ b/components/journal/RichTextEditor.tsx
@@ -562,15 +562,17 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
       
       {/* Editor Content */}
       <div className="border border-slate-200 dark:border-slate-600 border-t-0 rounded-b-xl bg-white dark:bg-slate-800 overflow-hidden relative">
-        <EditorContent 
-          editor={editor} 
-          className="prose-editor"
-        />
+        <div className="h-full overflow-y-auto scrollbar-thin scrollbar-thumb-slate-300 dark:scrollbar-thumb-slate-600 scrollbar-track-transparent">
+          <EditorContent 
+            editor={editor} 
+            className="prose-editor"
+          />
+        </div>
         
         {/* Slash Command Menu */}
         {showSlashMenu && (
           <div 
-            className="fixed z-[999] bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg shadow-xl py-2 min-w-[280px] max-h-[300px] overflow-y-auto"
+            className="fixed z-[9999] bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg shadow-xl py-2 min-w-[280px] max-h-[300px] overflow-y-auto"
             style={{
               left: Math.max(10, slashMenuPosition.x),
               top: Math.max(10, slashMenuPosition.y),
@@ -615,10 +617,15 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
       <style jsx global>{`
         .prose-editor .ProseMirror {
           min-height: 300px;
+          max-height: none;
           outline: none;
           padding: 1.5rem;
           color: rgb(51 65 85);
           line-height: 1.7;
+          overflow-wrap: break-word;
+          word-wrap: break-word;
+          word-break: break-word;
+          height: auto;
         }
         
         .dark .prose-editor .ProseMirror {
@@ -916,6 +923,17 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
         .prose-editor .ProseMirror ul[data-type="taskList"],
         .prose-editor .ProseMirror ol,
         .prose-editor .ProseMirror ul {
+          touch-action: pan-y;
+          -webkit-overflow-scrolling: touch;
+        }
+        
+        /* Enhanced scrolling for the entire editor */
+        .prose-editor {
+          -webkit-overflow-scrolling: touch;
+          scroll-behavior: smooth;
+        }
+        
+        .prose-editor .ProseMirror {
           touch-action: pan-y;
           -webkit-overflow-scrolling: touch;
         }

--- a/components/journal/RichTextEditor.tsx
+++ b/components/journal/RichTextEditor.tsx
@@ -281,9 +281,9 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
   }
 
   return (
-    <div className="rich-text-editor w-full relative">
-      {/* Toolbar */}
-      <div className="toolbar bg-white dark:bg-slate-800 rounded-t-xl p-3 flex flex-wrap gap-1 border border-slate-200 dark:border-slate-600 border-b-0">
+    <div className="rich-text-editor w-full relative h-full flex flex-col">
+              {/* Toolbar */}
+        <div className="toolbar bg-white dark:bg-slate-800 rounded-t-xl p-3 flex flex-wrap gap-1 border border-slate-200 dark:border-slate-600 border-b-0 flex-shrink-0">
         {/* Text formatting */}
         <div className="flex items-center space-x-1">
           <button
@@ -561,11 +561,11 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
       </div>
       
       {/* Editor Content */}
-      <div className="border border-slate-200 dark:border-slate-600 border-t-0 rounded-b-xl bg-white dark:bg-slate-800 overflow-hidden relative">
+      <div className="border border-slate-200 dark:border-slate-600 border-t-0 rounded-b-xl bg-white dark:bg-slate-800 overflow-hidden relative flex-1 min-h-0 max-h-full">
         <div className="h-full overflow-y-auto scrollbar-thin scrollbar-thumb-slate-300 dark:scrollbar-thumb-slate-600 scrollbar-track-transparent">
           <EditorContent 
             editor={editor} 
-            className="prose-editor"
+            className="prose-editor h-full"
           />
         </div>
         
@@ -615,9 +615,23 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
       </div>
       
       <style jsx global>{`
+        .prose-editor {
+          height: 100%;
+          display: flex;
+          flex-direction: column;
+          min-height: 0;
+        }
+        
+        .rich-text-editor {
+          height: 100%;
+          display: flex;
+          flex-direction: column;
+          min-height: 0;
+        }
+        
         .prose-editor .ProseMirror {
           min-height: 300px;
-          max-height: none;
+          max-height: 100%;
           outline: none;
           padding: 1.5rem;
           color: rgb(51 65 85);
@@ -626,6 +640,13 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
           word-wrap: break-word;
           word-break: break-word;
           height: auto;
+          flex: 1;
+          overflow-y: auto;
+          overflow-x: hidden;
+        }
+        
+        .prose-editor .ProseMirror:focus {
+          outline: none;
         }
         
         .dark .prose-editor .ProseMirror {

--- a/components/notes/NoteDetail.tsx
+++ b/components/notes/NoteDetail.tsx
@@ -10,6 +10,7 @@ import {
   TrashIcon, 
   CheckIcon 
 } from '@heroicons/react/24/solid';
+import { createPortal } from 'react-dom';
 
 type NoteDetailProps = {
   note: Note;
@@ -55,7 +56,7 @@ export default function NoteDetail({ note, onSave, onDelete, isSaving, existingT
   };
 
   return (
-    <div className="h-full flex flex-col bg-white dark:bg-slate-800">
+    <div className="h-full flex flex-col bg-white dark:bg-slate-800 relative z-10">
       {/* Header */}
       <div className="border-b border-neutral-200/50 dark:border-neutral-700/50 bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm">
         <div className="p-6">
@@ -90,6 +91,7 @@ export default function NoteDetail({ note, onSave, onDelete, isSaving, existingT
                   placeholder="Add tags..."
                   classNamePrefix="react-select"
                   className="text-sm"
+                  menuPortalTarget={typeof document !== 'undefined' ? document.body : null}
                   styles={{
                     control: (base) => ({
                       ...base,
@@ -100,7 +102,12 @@ export default function NoteDetail({ note, onSave, onDelete, isSaving, existingT
                     }),
                     menu: (base) => ({
                       ...base,
-                      zIndex: 9999,
+                      zIndex: 99999,
+                      position: 'absolute',
+                    }),
+                    menuPortal: (base) => ({
+                      ...base,
+                      zIndex: 99999,
                     }),
                     multiValue: (base) => ({
                       ...base,
@@ -171,7 +178,7 @@ export default function NoteDetail({ note, onSave, onDelete, isSaving, existingT
       </div>
 
       {/* Rich Text Editor */}
-      <div className="flex-1 overflow-hidden">
+      <div className="flex-1 overflow-hidden min-h-0">
         <div className="h-full flex flex-col">
           <RichTextEditor
             content={content}

--- a/components/notes/NoteDetail.tsx
+++ b/components/notes/NoteDetail.tsx
@@ -98,6 +98,10 @@ export default function NoteDetail({ note, onSave, onDelete, isSaving, existingT
                       minHeight: '40px',
                       fontSize: '0.875rem',
                     }),
+                    menu: (base) => ({
+                      ...base,
+                      zIndex: 9999,
+                    }),
                     multiValue: (base) => ({
                       ...base,
                       backgroundColor: 'rgb(240 253 250)',
@@ -168,7 +172,7 @@ export default function NoteDetail({ note, onSave, onDelete, isSaving, existingT
 
       {/* Rich Text Editor */}
       <div className="flex-1 overflow-hidden">
-        <div className="h-full">
+        <div className="h-full flex flex-col">
           <RichTextEditor
             content={content}
             onChange={setContent}


### PR DESCRIPTION
Fixes scrolling for long notes in the rich text editor and ensures the tags dropdown appears above the text entry.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d692796-bf51-4c6f-a9ac-49e22bb2c4ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d692796-bf51-4c6f-a9ac-49e22bb2c4ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>