### PR TITLE
Remove Vercel cron for Power Automate sync

### DIFF
--- a/.github/workflows/power-automate-sync.yml
+++ b/.github/workflows/power-automate-sync.yml
@@ -1,0 +1,37 @@
+name: Power Automate Sync
+
+on:
+  schedule:
+    # Run every 6 hours (at 00:00, 06:00, 12:00, 18:00 UTC)
+    - cron: '0 */6 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Power Automate sync
+        env:
+          # Add your environment variables here
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # Add any other environment variables your sync script needs
+        run: |
+          echo "Starting Power Automate sync job..."
+          npx tsx scripts/power-automate-cron.ts
+          echo "Power Automate sync job completed"

--- a/docs/POWER_AUTOMATE_CRON_SETUP.md
+++ b/docs/POWER_AUTOMATE_CRON_SETUP.md
@@ -1,0 +1,124 @@
+# Power Automate Sync Cron Job Setup
+
+This document explains how to set up automated Power Automate sync without requiring Vercel Pro.
+
+## Available Options
+
+### 1. GitHub Actions (Recommended)
+
+The GitHub Actions workflow runs automatically every 6 hours and is completely free for public repositories.
+
+**Setup:**
+1. The workflow file is already included at `.github/workflows/power-automate-sync.yml`
+2. Add the following secrets to your GitHub repository:
+   - `DATABASE_URL` - Your database connection string
+   - `NEXT_PUBLIC_SUPABASE_URL` - Your Supabase URL
+   - `NEXT_PUBLIC_SUPABASE_ANON_KEY` - Your Supabase anonymous key
+   - `SUPABASE_SERVICE_ROLE_KEY` - Your Supabase service role key
+   - `CRON_SECRET` - A secret token for authentication (same as your app)
+
+**To add secrets:**
+1. Go to your GitHub repository
+2. Click on "Settings" tab
+3. Click on "Secrets and variables" → "Actions"
+4. Click "New repository secret" and add each secret
+
+**Manual triggering:**
+You can manually trigger the sync by going to the "Actions" tab in your GitHub repository and clicking "Run workflow" on the "Power Automate Sync" workflow.
+
+### 2. External Webhook Cron Services
+
+Use free external cron services that can call your API endpoint via webhook.
+
+**Recommended free services:**
+- [cron-job.org](https://cron-job.org) - Free, reliable, easy to use
+- [EasyCron](https://www.easycron.com) - Free tier available
+- [Crontab.guru](https://crontab.guru) - For cron expression help
+
+**Setup with cron-job.org:**
+1. Sign up at [cron-job.org](https://cron-job.org)
+2. Create a new cron job with:
+   - **URL:** `https://yourdomain.com/api/cron/power-automate-sync?secret=YOUR_CRON_SECRET`
+   - **Schedule:** `0 */6 * * *` (every 6 hours)
+   - **Method:** GET or POST
+   - **Optional:** Add header `X-Webhook-Secret: YOUR_CRON_SECRET`
+
+**Environment Variables Required:**
+- `CRON_SECRET` - A secure random string for authentication
+
+### 3. Local/Server Cron (Self-hosted)
+
+If you're self-hosting, you can use system cron.
+
+**Setup:**
+1. Add to your crontab:
+   ```bash
+   # Run every 6 hours
+   0 */6 * * * cd /path/to/your/app && npx tsx scripts/power-automate-cron.ts
+   ```
+
+2. Or use the API endpoint:
+   ```bash
+   # Add to crontab
+   0 */6 * * * curl -X POST "https://yourdomain.com/api/cron/power-automate-sync" -H "Authorization: Bearer YOUR_CRON_SECRET"
+   ```
+
+## API Endpoint Details
+
+The sync endpoint is available at `/api/cron/power-automate-sync` and supports:
+
+**Authentication Methods:**
+- `Authorization: Bearer YOUR_CRON_SECRET` header
+- `X-Webhook-Secret: YOUR_CRON_SECRET` header  
+- `?secret=YOUR_CRON_SECRET` query parameter
+
+**HTTP Methods:**
+- `POST` (traditional)
+- `GET` (for simple webhook services)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Power Automate sync cron job completed",
+  "summary": {
+    "totalUsers": 5,
+    "successfulUsers": 4,
+    "failedUsers": 1,
+    "totalErrors": 2
+  },
+  "results": [...]
+}
+```
+
+## Manual Sync
+
+You can also run the sync manually:
+
+```bash
+# Direct script execution
+npx tsx scripts/power-automate-cron.ts
+
+# Via API call
+curl -X POST "https://yourdomain.com/api/cron/power-automate-sync" \
+  -H "Authorization: Bearer YOUR_CRON_SECRET"
+```
+
+## Security Notes
+
+- Always use a strong, random `CRON_SECRET`
+- Consider IP whitelisting if your hosting provider supports it
+- Monitor sync logs regularly for errors
+- The endpoint includes rate limiting and error handling
+
+## Troubleshooting
+
+**Common Issues:**
+1. **401 Unauthorized:** Check your `CRON_SECRET` environment variable
+2. **500 Error:** Check database connection and permissions
+3. **Sync failures:** Check individual user configurations and API limits
+
+**Logs:**
+- GitHub Actions: Check the "Actions" tab in your repository
+- Webhook services: Usually provide execution logs
+- Application logs: Check your hosting provider's logs

--- a/scripts/power-automate-cron.ts
+++ b/scripts/power-automate-cron.ts
@@ -6,14 +6,16 @@
  * This script can be run periodically (e.g., every 6 hours) to sync
  * Power Automate events for all users. It can be scheduled using:
  * 
- * - Vercel Cron Jobs (recommended)
- * - System cron
- * - GitHub Actions
- * - Any other cron service
+ * - GitHub Actions (recommended for free usage)
+ * - External webhook cron services (cron-job.org, EasyCron, etc.)
+ * - System cron (for self-hosted deployments)
+ * - Vercel Cron Jobs (requires Vercel Pro)
  * 
  * Usage:
- * - For Vercel: Add to vercel.json
- * - For local: Run with tsx scripts/power-automate-cron.ts
+ * - For GitHub Actions: See .github/workflows/power-automate-sync.yml
+ * - For webhook services: Call /api/cron/power-automate-sync endpoint
+ * - For local: Run with npx tsx scripts/power-automate-cron.ts
+ * - See docs/POWER_AUTOMATE_CRON_SETUP.md for detailed setup instructions
  */
 
 import { db } from '../lib/drizzle';

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,1 @@
-{
-  "crons": [
-    {
-      "path": "/api/cron/power-automate-sync",
-      "schedule": "0 */6 * * *"
-    }
-  ]
-}
+{}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Replaced Vercel Pro cron jobs with free alternatives to enable builds without a paid plan.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous setup used Vercel Cron Jobs, which require a Vercel Pro plan. This PR removes the Vercel cron configuration and introduces GitHub Actions as a primary free alternative, while also enhancing the API endpoint to support external webhook services for scheduling the Power Automate sync.

---
<a href="https://cursor.com/background-agent?bcId=bc-f78f72df-3470-4df0-b097-fc2883605497">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f78f72df-3470-4df0-b097-fc2883605497">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>